### PR TITLE
feat(content-details): add link to original article

### DIFF
--- a/src/app/content-details/components/article-details/article-details.component.html
+++ b/src/app/content-details/components/article-details/article-details.component.html
@@ -25,4 +25,11 @@
   </div>
 
   <div class="article-content" [innerHTML]="post.content.rendered"></div>
+
+  <div class="original-article-link" *ngIf="post?.link">
+    <ion-button expand="block" fill="outline" (click)="openOriginalArticle()">
+      <ion-icon slot="start" name="open-outline"></ion-icon>
+      Voir l'article original
+    </ion-button>
+  </div>
 </div>

--- a/src/app/content-details/components/article-details/article-details.component.scss
+++ b/src/app/content-details/components/article-details/article-details.component.scss
@@ -22,6 +22,17 @@
     font-family: RobotoRegular, sans-serif;
   }
 
+  .original-article-link {
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--ion-color-light);
+
+    ion-button {
+      --border-radius: 8px;
+      font-family: RobotoMedium;
+    }
+  }
+
 }
 
 #header {

--- a/src/app/content-details/components/article-details/article-details.component.ts
+++ b/src/app/content-details/components/article-details/article-details.component.ts
@@ -4,6 +4,7 @@ import { mergeMap, filter } from 'rxjs/operators';
 import { Post } from "../../../models/content/wordpress/post";
 import { AudioContentService, AudioContentUrl } from '../../../provider/content/audio-content.service';
 import { MixedContentService, AthenaId } from '../../../provider/content/mixed-content.service';
+import { LinkService } from '../../../provider/helper/link.service';
 import { MetaMediaService } from '../../../provider/meta-media/meta-media.service';
 import { isNotNullOrUndefined } from '../../../utils/is-not-null-or-undefined/operator';
 
@@ -26,7 +27,14 @@ export class ArticleDetailsComponent implements OnInit {
   isAudioPlaying = false;
   constructor(private readonly audioContentService: AudioContentService,
     private readonly mixedContentService: MixedContentService,
-    private readonly metaMediaService: MetaMediaService) { }
+    private readonly metaMediaService: MetaMediaService,
+    private readonly linkService: LinkService) { }
+
+  openOriginalArticle(): void {
+    if (this.post?.link) {
+      this.linkService.launchInAppBrowser(this.post.link);
+    }
+  }
 
   ngOnInit(): void {
     this.audio$ = this.mixedContentService.getIdFromContentIdAndMediaKey(this.key, this.post.contentId + '')


### PR DESCRIPTION
## Summary
- Add "Voir l'article original" button at the bottom of article details
- Opens original article URL in system browser using InAppBrowser
- Button styled with separator line and consistent design

Closes #314

## Test plan
- [ ] Open any article from the feed
- [ ] Scroll to bottom of article
- [ ] Tap "Voir l'article original" button
- [ ] Verify browser opens with the original article URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)