### PR TITLE
fix(link-service): fix hyperlinks not working in article content

### DIFF
--- a/src/app/content-details/content-details.page.ts
+++ b/src/app/content-details/content-details.page.ts
@@ -68,6 +68,8 @@ export class ContentDetailsPage implements OnInit, OnDestroy, Helpable {
     this.contentService.getContentById(this.id).subscribe((content) => {
       this.content = content;
       this.content.id = this.id;
+      // Enable hyperlinks after content is loaded
+      this.linkService.enableDynamicHyperlinks(this.element);
     });
 
     this.markContentAsRead(this.key);
@@ -79,7 +81,6 @@ export class ContentDetailsPage implements OnInit, OnDestroy, Helpable {
    */
   ngOnInit() {
     this.styleService.initPage();
-    this.linkService.enableDynamicHyperlinks(this.element);
   }
 
   async ngAfterViewInit(): Promise<void> {

--- a/src/app/provider/helper/link.service.ts
+++ b/src/app/provider/helper/link.service.ts
@@ -23,14 +23,15 @@ export class LinkService {
       urls.forEach((url: any) => {
         // Listen for a click event on each hyperlink found
         url.addEventListener('click', (event: any) => {
-          // Retrieve the href value from the selected hyperlink
+          // Retrieve the href value from the <a> element itself, not event.target
+          // (event.target could be a child element like <span>)
           event.preventDefault();
-          const link = event.target.href;
+          const link = url.href;
 
           // Log values to the console and open the link within the InAppBrowser plugin
-          console.log('Name is: ' + event.target.innerText);
+          console.log('Name is: ' + url.innerText);
           console.log('Link is: ' + link);
-          if (link != null) {
+          if (link != null && link !== 'undefined' && link !== '') {
             this.launchInAppBrowser(link);
           }
         }, false);


### PR DESCRIPTION
## Summary
- Fix hyperlinks in article content not working when clicking on child elements (like `<span>`)
- Use `url.href` instead of `event.target.href` to properly get the link URL
- Move `enableDynamicHyperlinks` call after content is loaded (was called before content rendered)
- Add validation to prevent opening undefined/empty links

Closes #323

## Test plan
- [ ] Open an article with "lire aussi" links
- [ ] Click on any hyperlink in the article content
- [ ] Verify browser opens with the correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)