### PR TITLE
fix(reading-progress): fix progress bar not visible on mobile

### DIFF
--- a/src/app/content-details/components/reading-progress/reading-progress.component.html
+++ b/src/app/content-details/components/reading-progress/reading-progress.component.html
@@ -1,1 +1,3 @@
-<div class="progress-bar" [style.width]="progress + '%'"></div>
+<div class="progress-container">
+  <div class="progress-bar" [style.width]="progress + '%'"></div>
+</div>

--- a/src/app/content-details/components/reading-progress/reading-progress.component.scss
+++ b/src/app/content-details/components/reading-progress/reading-progress.component.scss
@@ -1,10 +1,21 @@
 :host {
+  display: block;
   padding-left: 1rem;
   padding-right: 1rem;
-  .progress-bar {
-    height: 1rem;
+
+  .progress-container {
+    height: 0.5rem;
     width: 100%;
-    background-color: #000000aa;
+    background-color: rgba(255, 255, 255, 0.2);
     border-radius: 10px;
+    overflow: hidden;
+  }
+
+  .progress-bar {
+    height: 100%;
+    width: 0%;
+    background-color: var(--ion-color-primary);
+    border-radius: 10px;
+    transition: width 0.1s ease-out;
   }
 }

--- a/src/app/content-details/content-details.page.scss
+++ b/src/app/content-details/content-details.page.scss
@@ -13,7 +13,9 @@
 
   ath-reading-progress {
     position: fixed;
-    bottom: 0.5rem;
-    width: 100%;
+    bottom: calc(0.5rem + env(safe-area-inset-bottom));
+    left: 0;
+    right: 0;
+    z-index: 10;
   }
 }

--- a/src/app/content-details/content-details.page.ts
+++ b/src/app/content-details/content-details.page.ts
@@ -70,6 +70,8 @@ export class ContentDetailsPage implements OnInit, OnDestroy, Helpable {
       this.content.id = this.id;
       // Enable hyperlinks after content is loaded
       this.linkService.enableDynamicHyperlinks(this.element);
+      // Recalculate max height after content is loaded
+      this.updateMaxHeight();
     });
 
     this.markContentAsRead(this.key);
@@ -84,10 +86,15 @@ export class ContentDetailsPage implements OnInit, OnDestroy, Helpable {
   }
 
   async ngAfterViewInit(): Promise<void> {
+    this.updateMaxHeight();
+  }
+
+  private async updateMaxHeight(): Promise<void> {
+    // Wait for content to render
     setTimeout(async () => {
       const scrollElement = await this.ionContent.getScrollElement();
       this.maxHeight = scrollElement.scrollHeight;
-    }, 100);
+    }, 500);
   }
   /**
    * Quand il quitte la page il faut rétablir dans le sens inverse si besoin


### PR DESCRIPTION
## Summary
- Add progress container with semi-transparent background for better visibility
- Fix position: fixed positioning with left/right instead of width
- Add safe-area-inset-bottom for iPhone notch
- Recalculate maxHeight after content loads (fixes 100% progress on load)
- Smoother transition animation

Closes #150

## Test plan
- [ ] Open an article on Android - progress bar visible at bottom
- [ ] Open an article on iOS - progress bar visible at bottom with safe area
- [ ] Scroll article - progress bar fills progressively
- [ ] Reach end of article - progress bar at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)