### PR TITLE
feat(feed): add pull-to-refresh on feed and media pages

### DIFF
--- a/src/app/media/media.page.html
+++ b/src/app/media/media.page.html
@@ -1,4 +1,9 @@
 <ion-content>
+  <ion-refresher slot="fixed" (ionRefresh)="doRefresh($event)">
+    <ion-refresher-content pullingText="Tirer pour rafraîchir" refreshingSpinner="circles"
+      refreshingText="Chargement...">
+    </ion-refresher-content>
+  </ion-refresher>
 
   <div>
     <ion-list>

--- a/src/app/media/media.page.ts
+++ b/src/app/media/media.page.ts
@@ -66,6 +66,21 @@ export class MediaPage implements OnInit {
       });
   }
 
+  doRefresh(event: any) {
+    this.loading = true;
+    this.contentService.getContents()
+      .subscribe((page: Page<IContent>) => {
+        this.page = page;
+        this.loading = false;
+        event.target.complete();
+      }, (error) => {
+        console.error("error media page refresh");
+        console.error(error);
+        this.loading = false;
+        event.target.complete();
+      });
+  }
+
   /**
    * Cette methode est déclanché quand l'utilisateur scroll tout en bas de son téléphone
    * @param event l'event javascript

--- a/src/app/pages/feed/feed.page.html
+++ b/src/app/pages/feed/feed.page.html
@@ -1,4 +1,10 @@
 <ion-content>
+  <ion-refresher slot="fixed" (ionRefresh)="doRefresh($event)">
+    <ion-refresher-content pullingText="Tirer pour rafraîchir" refreshingSpinner="circles"
+      refreshingText="Chargement...">
+    </ion-refresher-content>
+  </ion-refresher>
+
   <div class="search-row">
     <ion-searchbar debounce="500" animated mode="ios" (ionChange)="searchTermsChanged($any($event))"></ion-searchbar>
     <ion-button fill="clear" (click)="openFilterModal()" class="filter-button">

--- a/src/app/pages/feed/feed.page.ts
+++ b/src/app/pages/feed/feed.page.ts
@@ -61,6 +61,27 @@ export class FeedPage implements OnInit {
       });
   }
 
+  doRefresh(event: any) {
+    this.page = 1;
+    this.contents = [];
+    if (this.infiniteScroll?.disabled === true) {
+      this.infiniteScroll.disabled = false;
+    }
+
+    const mediaKeysParam = this.mediaKeys.length > 0 ? this.mediaKeys.join(',') : undefined;
+
+    this.mixedContentService
+      .getLastFeedContent(this.page, this.size, this.terms, mediaKeysParam)
+      .subscribe((pageResult) => {
+        this.contents = pageResult.objects;
+        this.page = pageResult.next;
+        event.target.complete();
+        if (pageResult.next === undefined) {
+          this.infiniteScroll.disabled = true;
+        }
+      });
+  }
+
   private initSearch() {
     this.page = 1;
     this.contents = [];


### PR DESCRIPTION
## Summary
- Add pull-to-refresh (ion-refresher) to feed page for global article list
- Add pull-to-refresh to media page for individual media content list
- Pull down to reload content from API

Closes #225

## Test plan
- [ ] Open feed page, pull down to refresh
- [ ] Open a media page, pull down to refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)