### PR TITLE
fix(ui): adjust theme for new gradient background

### DIFF
--- a/src/app/pages/construction/construction.page.scss
+++ b/src/app/pages/construction/construction.page.scss
@@ -3,6 +3,15 @@
 
     ion-segment {
       margin-bottom: 2rem;
+
+      ion-segment-button {
+        --color: rgba(255, 255, 255, 0.6);
+        --color-checked: var(--ion-color-primary);
+
+        ion-icon {
+          color: inherit;
+        }
+      }
     }
 
     ath-section {

--- a/src/app/pages/tabs/tabs.page.scss
+++ b/src/app/pages/tabs/tabs.page.scss
@@ -1,9 +1,12 @@
 ion-tabs {
-  background-color: #DDDDDD;
+  background-color: transparent;
 }
 
 ion-tab-bar {
-  --background: var(--ion-color-dark-glass);
+  --background: rgba(15, 32, 39, 0.85);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 16px;
   margin: 1.5%;
   padding: 0;

--- a/src/global.scss
+++ b/src/global.scss
@@ -16,8 +16,7 @@
 
 body {
   --background: #0F2027;
-  --ion-background-color: linear-gradient(to right, #2C5364, #203A43, #0F2027);
-  /* W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */
+  --ion-background-color: radial-gradient(ellipse at top left, #1a3a4a 0%, #152a35 40%, #0F2027 100%);
   --ion-text-color: white;
 
   --primaryColor: #000000;
@@ -184,7 +183,7 @@ ion-modal {
 
 
 .ath-alert {
-  --background: linear-gradient(to right, #485563, #29323c);
+  --background: #152a35;
 }
 
 


### PR DESCRIPTION
## Summary
- Change gradient to subtle radial from top-left corner (less aggressive transition)
- Fix segment icons on "Améliorations" page to be white instead of dark
- Update tab bar with glass morphism effect (blurred, semi-transparent) matching blue theme
- Harmonize alert background color with new theme

## Test plan
- [ ] Verify gradient is subtle and pleasant across all pages
- [ ] Verify segment icons (Média, Idées, Bugs) are white/orange
- [ ] Verify tab bar blends well with background

🤖 Generated with [Claude Code](https://claude.com/claude-code)