### PR TITLE
feat(mobile): uniformisation PWA↔mobile - dédup votes, favoris, master switch notifs, downvote

### DIFF
--- a/src/app/content-details/content-details.page.html
+++ b/src/app/content-details/content-details.page.html
@@ -17,6 +17,13 @@
 
   <ath-reading-progress [progress]="readingProgress"></ath-reading-progress>
 
+  <ion-fab vertical="bottom" horizontal="start" slot="fixed">
+    <ion-fab-button color="dark" (click)="toggleFavorite()"
+      [attr.aria-label]="isSaved ? 'Retirer des enregistrés' : 'Enregistrer'">
+      <ion-icon [name]="isSaved ? 'bookmark' : 'bookmark-outline'"></ion-icon>
+    </ion-fab-button>
+  </ion-fab>
+
   <ion-fab vertical="bottom" horizontal="end" slot="fixed">
     <ion-button class="share-fab" shape="round" color="primary" (click)="shareContent()">
       <ion-icon name="share-social-outline" slot="start"></ion-icon>

--- a/src/app/content-details/content-details.page.ts
+++ b/src/app/content-details/content-details.page.ts
@@ -16,6 +16,9 @@ import { LinkService } from "../provider/helper/link.service";
 import { StorageService } from "../provider/helper/storage.service";
 import { StyleService } from "../provider/style.service";
 import { PodcastService } from "../provider/podcast/podcast.service";
+import { FavoritesService } from "../provider/favorites.service";
+import { MetaMediaService } from "../provider/meta-media/meta-media.service";
+import { buildFavoriteKey, SavedArticle } from "../models/favorite/saved-article";
 import { shareContent } from './utils/shareable-content.utils';
 
 /**
@@ -45,7 +48,9 @@ export class ContentDetailsPage implements OnInit, OnDestroy, Helpable {
     public helpService: HelpService,
     public element: ElementRef,
     private readonly storage: StorageService,
-    private readonly podcastService: PodcastService
+    private readonly podcastService: PodcastService,
+    private readonly favoritesService: FavoritesService,
+    private readonly metaMediaService: MetaMediaService
   ) { }
 
   private static scrollDeltaY = -500;
@@ -143,6 +148,31 @@ export class ContentDetailsPage implements OnInit, OnDestroy, Helpable {
 
   async shareContent() {
     await shareContent(this.key, this.id, "Regarde ce que j'ai trouvé")
+  }
+
+  /** Vrai si l'article courant est dans les favoris. */
+  get isSaved(): boolean {
+    return this.favoritesService.isSaved(buildFavoriteKey(this.key, this.id));
+  }
+
+  /** Bascule l'article courant dans/hors des favoris (stockage local). */
+  toggleFavorite(): void {
+    const meta = this.metaMediaService.currentMetaMedia;
+    const article: SavedArticle = {
+      key: buildFavoriteKey(this.key, this.id),
+      resourceId: this.id,
+      mediaKey: this.key,
+      title: this.content?.title ?? '',
+      publishedAt: this.content?.publishedAt
+        ? new Date(this.content.publishedAt).toISOString()
+        : '',
+      imageUrl: this.content?.image?.url,
+      mediaTitle: meta?.title ?? '',
+      mediaLogo: meta?.logo,
+      mediaType: (meta?.type as string) ?? '',
+      savedAt: new Date().toISOString(),
+    };
+    this.favoritesService.toggleArticle(article);
   }
 
   async scrollTop() {

--- a/src/app/models/favorite/saved-article.ts
+++ b/src/app/models/favorite/saved-article.ts
@@ -1,0 +1,46 @@
+import { MixedContent } from '../../provider/content/mixed-content';
+
+/**
+ * Article enregistré (favori), persisté localement (SQLite). Miroir mobile de
+ * la reading-list de la PWA. On stocke le minimum nécessaire pour réafficher la
+ * carte et renaviguer vers l'article hors-ligne.
+ *
+ * La clé de dédup est `key = mediaKey:resourceId` : c'est le seul identifiant
+ * stable disponible AUSSI BIEN depuis le feed (MixedContent) que depuis la page
+ * détail (où l'id interne du feed n'est pas connu).
+ */
+export interface SavedArticle {
+  /** Clé stable de dédup/navigation : `mediaKey:resourceId`. */
+  key: string;
+  /** Identifiant utilisé pour la navigation (resourceId : contentId WP ou id YT). */
+  resourceId: number | string;
+  mediaKey: string;
+  title: string;
+  publishedAt: string;
+  imageUrl?: string;
+  mediaTitle: string;
+  mediaLogo?: string;
+  mediaType: string;
+  savedAt: string;
+}
+
+/** Construit la clé de favori à partir d'une clé média et d'un resourceId. */
+export function buildFavoriteKey(mediaKey: string, resourceId: number | string): string {
+  return `${mediaKey}:${resourceId}`;
+}
+
+/** Construit un SavedArticle à partir d'un MixedContent du feed. */
+export function toSavedArticle(content: MixedContent): SavedArticle {
+  return {
+    key: buildFavoriteKey(content.metaMedia.key, content.resourceId),
+    resourceId: content.resourceId,
+    mediaKey: content.metaMedia.key,
+    title: content.title,
+    publishedAt: content.publishedAt,
+    imageUrl: content.image?.url,
+    mediaTitle: content.metaMedia.title,
+    mediaLogo: content.metaMedia.logo,
+    mediaType: content.metaMedia.type,
+    savedAt: new Date().toISOString(),
+  };
+}

--- a/src/app/models/idea/idea.ts
+++ b/src/app/models/idea/idea.ts
@@ -23,6 +23,7 @@ export interface Issue {
   author_association?: string;
   body?: string;
   hasBeenClapped?: boolean;
+  hasBeenDownvoted?: boolean;
 }
 
 export interface Label {

--- a/src/app/pages/construction/components/issues-list/issues-list.component.html
+++ b/src/app/pages/construction/components/issues-list/issues-list.component.html
@@ -3,8 +3,17 @@
     {{issue?.title}}
   </ion-label>
 
-  <ion-button shape="round" fill="clear" [disabled]="issue.hasBeenClapped" (click)="clapIssue($event, issue); false">
-    <ion-icon slot="icon-only" src="assets/clap.svg"></ion-icon>
-    {{issue?.comments}}
-  </ion-button>
+  <div class="vote-actions" slot="end">
+    <ion-button shape="round" fill="clear" [color]="issue.hasBeenClapped ? 'primary' : 'medium'"
+      (click)="clapIssue($event, issue); false">
+      <ion-icon slot="icon-only" src="assets/clap.svg"></ion-icon>
+    </ion-button>
+
+    <span class="vote-count">{{issue?.comments}}</span>
+
+    <ion-button shape="round" fill="clear" [color]="issue.hasBeenDownvoted ? 'danger' : 'medium'"
+      (click)="downvoteIssue($event, issue); false">
+      <ion-icon slot="icon-only" [name]="issue.hasBeenDownvoted ? 'thumbs-down' : 'thumbs-down-outline'"></ion-icon>
+    </ion-button>
+  </div>
 </ion-item>

--- a/src/app/pages/construction/components/issues-list/issues-list.component.scss
+++ b/src/app/pages/construction/components/issues-list/issues-list.component.scss
@@ -26,23 +26,31 @@ ion-item {
     color: var(--ath-text);
   }
 
-  ion-button {
-    --color: var(--ath-text-dim);
-    --background: var(--ath-surface-2);
-    --border-radius: var(--ath-radius-full);
-    --padding-start: 10px;
-    --padding-end: 12px;
-    height: 34px;
-    margin: 0;
+  .vote-actions {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+  }
+
+  .vote-count {
+    min-width: 22px;
+    text-align: center;
     font-family: var(--ath-font-ui);
     font-weight: 700;
     font-size: 13px;
-    letter-spacing: .01em;
+    color: var(--ath-text);
+  }
+
+  ion-button {
+    --background: transparent;
+    --border-radius: var(--ath-radius-full);
+    --padding-start: 8px;
+    --padding-end: 8px;
+    height: 34px;
+    margin: 0;
 
     ion-icon {
-      color: var(--ath-primary);
-      margin-right: 4px;
-      font-size: 16px;
+      font-size: 18px;
     }
 
     &[disabled] {

--- a/src/app/pages/construction/components/issues-list/issues-list.component.ts
+++ b/src/app/pages/construction/components/issues-list/issues-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Issue } from './../../../../models/idea/idea';
 
 @Component({
@@ -10,9 +10,15 @@ export class IssuesListComponent {
 
   @Input() issues: Issue[] = [];
   @Output() claped = new EventEmitter<Issue>();
+  @Output() downvoted = new EventEmitter<Issue>();
 
   clapIssue(event: any, issue: Issue) {
     event.stopPropagation();
     this.claped.emit(issue);
+  }
+
+  downvoteIssue(event: any, issue: Issue) {
+    event.stopPropagation();
+    this.downvoted.emit(issue);
   }
 }

--- a/src/app/pages/construction/construction.page.html
+++ b/src/app/pages/construction/construction.page.html
@@ -25,7 +25,7 @@
 
 
   <ath-loading [loading]="loading">
-    <ath-issues-list [issues]="issues" (claped)="clap($event)"></ath-issues-list>
+    <ath-issues-list [issues]="issues" (claped)="clap($event)" (downvoted)="downvote($event)"></ath-issues-list>
   </ath-loading>
 
 

--- a/src/app/pages/construction/construction.page.ts
+++ b/src/app/pages/construction/construction.page.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { AlertController, ModalController } from '@ionic/angular';
 import { EMPTY, Observable } from 'rxjs';
-import { mergeMap } from 'rxjs/operators';
+import { mergeMap, tap } from 'rxjs/operators';
 import { Issue } from '../../models/idea/idea';
 import { FirebaseAuthService } from '../../provider/auth/firebase-auth.service';
 import { IdeaService } from '../../provider/idea.service';
@@ -55,8 +55,11 @@ export class ConstructionPage implements OnInit {
   clap(issue: Issue) {
     if (issue.hasBeenClapped) {
       this.ideaService.deleteClap(issue)
-        .pipe(mergeMap(() => this.storage.removeFromArray(StorageService.CLAPPED_ISSUE, issue.id)))
-        .subscribe((updated) => this.applyVoteResult(issue, updated, { clapped: false }));
+        .pipe(
+          tap((updated) => this.applyVoteResult(issue, updated, { clapped: false })),
+          mergeMap(() => this.storage.removeFromArray(StorageService.CLAPPED_ISSUE, issue.id))
+        )
+        .subscribe();
       return;
     }
 
@@ -70,8 +73,11 @@ export class ConstructionPage implements OnInit {
         issue.hasBeenDownvoted = false;
       }
       this.ideaService.postClapComment(issue)
-        .pipe(mergeMap(() => this.storage.addToArray(StorageService.CLAPPED_ISSUE, issue.id)))
-        .subscribe((updated) => this.applyVoteResult(issue, updated, { clapped: true }));
+        .pipe(
+          tap((updated) => this.applyVoteResult(issue, updated, { clapped: true })),
+          mergeMap(() => this.storage.addToArray(StorageService.CLAPPED_ISSUE, issue.id))
+        )
+        .subscribe();
     });
   }
 
@@ -88,8 +94,11 @@ export class ConstructionPage implements OnInit {
 
     if (issue.hasBeenDownvoted) {
       this.ideaService.deleteDownvote(issue)
-        .pipe(mergeMap(() => this.storage.removeFromArray(StorageService.DOWNVOTED_ISSUE, issue.id)))
-        .subscribe((updated) => this.applyVoteResult(issue, updated, { downvoted: false }));
+        .pipe(
+          tap((updated) => this.applyVoteResult(issue, updated, { downvoted: false })),
+          mergeMap(() => this.storage.removeFromArray(StorageService.DOWNVOTED_ISSUE, issue.id))
+        )
+        .subscribe();
       return;
     }
 
@@ -103,8 +112,11 @@ export class ConstructionPage implements OnInit {
         issue.hasBeenClapped = false;
       }
       this.ideaService.postDownvote(issue)
-        .pipe(mergeMap(() => this.storage.addToArray(StorageService.DOWNVOTED_ISSUE, issue.id)))
-        .subscribe((updated) => this.applyVoteResult(issue, updated, { downvoted: true }));
+        .pipe(
+          tap((updated) => this.applyVoteResult(issue, updated, { downvoted: true })),
+          mergeMap(() => this.storage.addToArray(StorageService.DOWNVOTED_ISSUE, issue.id))
+        )
+        .subscribe();
     });
   }
 

--- a/src/app/pages/construction/construction.page.ts
+++ b/src/app/pages/construction/construction.page.ts
@@ -1,11 +1,14 @@
 import { Component, OnInit } from '@angular/core';
-import { ModalController } from '@ionic/angular';
+import { Router } from '@angular/router';
+import { AlertController, ModalController } from '@ionic/angular';
+import { EMPTY, Observable } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
 import { Issue } from '../../models/idea/idea';
+import { FirebaseAuthService } from '../../provider/auth/firebase-auth.service';
 import { IdeaService } from '../../provider/idea.service';
-import { IssueModalPage } from './components/issue/issue.modal';
 import { StorageService } from '../../provider/helper/storage.service';
 import { SecondaryMenuService } from '../../provider/secondary-menu.service';
-import { tap, mergeMap } from 'rxjs/operators';
+import { IssueModalPage } from './components/issue/issue.modal';
 
 @Component({
   selector: 'ath-construction',
@@ -23,7 +26,10 @@ export class ConstructionPage implements OnInit {
     private readonly ideaService: IdeaService,
     private readonly modalController: ModalController,
     private readonly storage: StorageService,
-    private readonly secondaryMenu: SecondaryMenuService
+    private readonly secondaryMenu: SecondaryMenuService,
+    private readonly authService: FirebaseAuthService,
+    private readonly alertController: AlertController,
+    private readonly router: Router
   ) { }
 
   openMoreMenu() {
@@ -41,15 +47,65 @@ export class ConstructionPage implements OnInit {
   }
 
 
+  /**
+   * Vote « pour » en toggle. Si l'idée était déjà downvotée, on retire d'abord
+   * le vote contre (états mutuellement exclusifs). Le compteur affiché suit la
+   * valeur nette renvoyée par le serveur.
+   */
   clap(issue: Issue) {
-    this.ideaService.postClapComment(issue)
-      .pipe(
-        mergeMap(() => this.storage.addToArray(StorageService.CLAPPED_ISSUE, issue.id))
-      )
-      .subscribe(() => {
-        issue.comments++;
-        issue.hasBeenClapped = true;
-      });
+    if (issue.hasBeenClapped) {
+      this.ideaService.deleteClap(issue)
+        .pipe(mergeMap(() => this.storage.removeFromArray(StorageService.CLAPPED_ISSUE, issue.id)))
+        .subscribe((updated) => this.applyVoteResult(issue, updated, { clapped: false }));
+      return;
+    }
+
+    const removeOpposite$ = issue.hasBeenDownvoted
+      ? this.ideaService.deleteDownvote(issue)
+      : EMPTY;
+
+    this.runAfter(removeOpposite$, () => {
+      if (issue.hasBeenDownvoted) {
+        this.storage.removeFromArray(StorageService.DOWNVOTED_ISSUE, issue.id).subscribe();
+        issue.hasBeenDownvoted = false;
+      }
+      this.ideaService.postClapComment(issue)
+        .pipe(mergeMap(() => this.storage.addToArray(StorageService.CLAPPED_ISSUE, issue.id)))
+        .subscribe((updated) => this.applyVoteResult(issue, updated, { clapped: true }));
+    });
+  }
+
+  /**
+   * Vote « contre » en toggle. Nécessite une connexion (Bearer Firebase). Si
+   * l'utilisateur n'est pas connecté, on l'invite à se connecter. Si l'idée
+   * était clappée, on retire d'abord le vote pour.
+   */
+  downvote(issue: Issue) {
+    if (!this.authService.isAuthenticated()) {
+      this.promptLogin();
+      return;
+    }
+
+    if (issue.hasBeenDownvoted) {
+      this.ideaService.deleteDownvote(issue)
+        .pipe(mergeMap(() => this.storage.removeFromArray(StorageService.DOWNVOTED_ISSUE, issue.id)))
+        .subscribe((updated) => this.applyVoteResult(issue, updated, { downvoted: false }));
+      return;
+    }
+
+    const removeOpposite$ = issue.hasBeenClapped
+      ? this.ideaService.deleteClap(issue)
+      : EMPTY;
+
+    this.runAfter(removeOpposite$, () => {
+      if (issue.hasBeenClapped) {
+        this.storage.removeFromArray(StorageService.CLAPPED_ISSUE, issue.id).subscribe();
+        issue.hasBeenClapped = false;
+      }
+      this.ideaService.postDownvote(issue)
+        .pipe(mergeMap(() => this.storage.addToArray(StorageService.DOWNVOTED_ISSUE, issue.id)))
+        .subscribe((updated) => this.applyVoteResult(issue, updated, { downvoted: true }));
+    });
   }
 
 
@@ -63,6 +119,52 @@ export class ConstructionPage implements OnInit {
     if (issue != null) {
       this.sendIssue(issue);
     }
+  }
+
+  /**
+   * Met à jour l'état local de l'idée à partir de la réponse serveur
+   * (compteur net) et des nouveaux drapeaux up/down.
+   */
+  private applyVoteResult(
+    issue: Issue,
+    updated: Issue,
+    flags: { clapped?: boolean; downvoted?: boolean }
+  ) {
+    if (updated && typeof updated.comments === 'number') {
+      issue.comments = updated.comments;
+    }
+    if (flags.clapped !== undefined) {
+      issue.hasBeenClapped = flags.clapped;
+    }
+    if (flags.downvoted !== undefined) {
+      issue.hasBeenDownvoted = flags.downvoted;
+    }
+  }
+
+  /**
+   * Exécute `then` après l'observable `before` (ou immédiatement si EMPTY).
+   */
+  private runAfter(before: Observable<unknown>, then: () => void) {
+    if (before === EMPTY) {
+      then();
+      return;
+    }
+    before.subscribe({ next: () => then(), error: () => then() });
+  }
+
+  private async promptLogin() {
+    const alert = await this.alertController.create({
+      header: 'Connexion requise',
+      message: 'Connectez-vous pour voter contre une idée.',
+      buttons: [
+        { text: 'Annuler', role: 'cancel' },
+        {
+          text: 'Se connecter',
+          handler: () => this.router.navigateByUrl('/login'),
+        },
+      ],
+    });
+    await alert.present();
   }
 
   private initIssuesByType(type: string) {

--- a/src/app/pages/feed/article-preview/article-preview.component.html
+++ b/src/app/pages/feed/article-preview/article-preview.component.html
@@ -12,6 +12,11 @@
       <span class="sig-card__source">{{mixedContent.metaMedia.title}}</span>
       <span class="sig-card__sep" *ngIf="mixedContent.publishedAt">·</span>
       <span class="sig-card__date" *ngIf="mixedContent.publishedAt">{{mixedContent.publishedAt | date:'d MMM yyyy'}}</span>
+      <button class="sig-card__save" type="button" [class.is-saved]="isSaved"
+        [attr.aria-label]="isSaved ? 'Retirer des enregistrés' : 'Enregistrer'"
+        (click)="toggleFavorite($event)">
+        <ion-icon [name]="isSaved ? 'bookmark' : 'bookmark-outline'"></ion-icon>
+      </button>
     </div>
     <h3 class="sig-card__title" [innerHTML]="mixedContent.title"></h3>
   </div>

--- a/src/app/pages/feed/article-preview/article-preview.component.scss
+++ b/src/app/pages/feed/article-preview/article-preview.component.scss
@@ -102,6 +102,33 @@
   flex-shrink: 0;
 }
 
+.sig-card__save {
+  margin-left: auto;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: var(--ath-text-dim);
+  cursor: pointer;
+
+  ion-icon {
+    font-size: 19px;
+  }
+
+  &:active ion-icon {
+    color: var(--ath-primary);
+  }
+
+  &.is-saved {
+    color: var(--ath-primary);
+  }
+}
+
 .sig-card__title {
   margin: 0;
   font-family: var(--ath-font-display);

--- a/src/app/pages/feed/article-preview/article-preview.component.ts
+++ b/src/app/pages/feed/article-preview/article-preview.component.ts
@@ -1,7 +1,9 @@
-import { Component, OnInit, ChangeDetectionStrategy, Input, Host, HostListener } from '@angular/core';
+import { Component, ChangeDetectionStrategy, Input, HostListener, ChangeDetectorRef } from '@angular/core';
 import { Router } from '@angular/router';
 import { MixedContent } from '../../../provider/content/mixed-content';
 import { MetaMediaType } from '../../../models/meta-media/meta-media-type.enum';
+import { FavoritesService } from '../../../provider/favorites.service';
+import { buildFavoriteKey } from '../../../models/favorite/saved-article';
 
 @Component({
   selector: 'ath-article-preview',
@@ -15,6 +17,22 @@ export class ArticlePreviewComponent {
 
   /** Passe à true si la version haute résolution YouTube n'existe pas. */
   imgFailed = false;
+
+  get isSaved(): boolean {
+    if (!this.mixedContent) {
+      return false;
+    }
+    return this.favoritesService.isSaved(
+      buildFavoriteKey(this.mixedContent.metaMedia.key, this.mixedContent.resourceId)
+    );
+  }
+
+  /** Bascule le favori sans déclencher la navigation de la carte. */
+  toggleFavorite(event: Event): void {
+    event.stopPropagation();
+    this.favoritesService.toggle(this.mixedContent);
+    this.cdr.markForCheck();
+  }
 
   get isVideo(): boolean {
     const type = this.mixedContent?.metaMedia?.type;
@@ -49,7 +67,11 @@ export class ArticlePreviewComponent {
     this.goToContentDetails();
   }
 
-  constructor(private readonly router: Router) { }
+  constructor(
+    private readonly router: Router,
+    private readonly favoritesService: FavoritesService,
+    private readonly cdr: ChangeDetectorRef
+  ) { }
 
   private goToContentDetails() {
     this.router.navigate(['/', 'media', this.mixedContent.metaMedia.key, 'details', this.mixedContent.resourceId]);

--- a/src/app/pages/informations/informations.page.html
+++ b/src/app/pages/informations/informations.page.html
@@ -11,6 +11,19 @@
   </div>
 
   <ion-list lines="full">
+    <!-- Master switch des notifications (#90) -->
+    <ion-item>
+      <ion-icon slot="start" name="notifications-outline" color="primary"></ion-icon>
+      <ion-label>
+        <h2>Notifications</h2>
+        <p>Activer ou couper toutes les notifications</p>
+      </ion-label>
+      <ion-toggle slot="end" [checked]="notificationsEnabled"
+        (ionChange)="onNotificationsToggle($any($event))"></ion-toggle>
+    </ion-item>
+  </ion-list>
+
+  <ion-list lines="full">
     <!-- Bouton de connexion/profil -->
     <ion-item button (click)="navigateToAuth()" *ngIf="!(user$ | async)">
       <ion-icon slot="start" name="log-in-outline" color="primary"></ion-icon>

--- a/src/app/pages/informations/informations.page.ts
+++ b/src/app/pages/informations/informations.page.ts
@@ -5,26 +5,54 @@ import { User } from '@capacitor-firebase/authentication';
 
 import { LinkService } from '../../provider/helper/link.service';
 import { FirebaseAuthService } from '../../provider/auth/firebase-auth.service';
+import { NotificationService } from '../../provider/notification.service';
 
 /**
  * Cette page permet d'afficher quelque informations supplémentaire sur l'application
  * - lien github
  * - esprit du projet
+ * - interrupteur global des notifications (#90)
  */
 @Component({
   selector: 'bf-informations',
   templateUrl: './informations.page.html',
   styleUrls: ['./informations.page.scss'],
 })
-export class InformationsPage {
+export class InformationsPage implements OnInit {
   user$: Observable<User | null>;
+
+  /** État du master switch des notifications (true = activées). */
+  notificationsEnabled = true;
+  /** Évite de redéclencher un (dés)abonnement lors de l'init du toggle. */
+  private notificationsToggleReady = false;
 
   constructor(
     private linkService: LinkService,
     private authService: FirebaseAuthService,
-    private router: Router
+    private router: Router,
+    private notificationService: NotificationService
   ) {
     this.user$ = this.authService.getCurrentUser();
+  }
+
+  ngOnInit() {
+    this.notificationService.isNotificationsMasterEnabled().subscribe((enabled) => {
+      this.notificationsEnabled = enabled;
+      this.notificationsToggleReady = true;
+    });
+  }
+
+  /**
+   * Coupe ou réactive toutes les notifications d'un coup. Ignore l'événement
+   * émis lors de l'initialisation du toggle (pas d'appel réseau inutile).
+   */
+  onNotificationsToggle(event: CustomEvent) {
+    const enabled = !!(event.detail as { checked?: boolean }).checked;
+    if (!this.notificationsToggleReady || enabled === this.notificationsEnabled) {
+      return;
+    }
+    this.notificationsEnabled = enabled;
+    this.notificationService.setAllNotifications(enabled).subscribe();
   }
 
   openLink(link: string) {

--- a/src/app/pages/saved/saved-routing.module.ts
+++ b/src/app/pages/saved/saved-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { SavedPage } from './saved.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: SavedPage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class SavedPageRoutingModule {}

--- a/src/app/pages/saved/saved.module.ts
+++ b/src/app/pages/saved/saved.module.ts
@@ -1,0 +1,19 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { IonicModule } from '@ionic/angular';
+import { ComponentsModule } from '../../components/components.module';
+import { SavedPageRoutingModule } from './saved-routing.module';
+import { SavedPage } from './saved.page';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    ComponentsModule,
+    SavedPageRoutingModule,
+  ],
+  declarations: [SavedPage],
+})
+export class SavedPageModule {}

--- a/src/app/pages/saved/saved.page.html
+++ b/src/app/pages/saved/saved.page.html
@@ -1,0 +1,35 @@
+<ion-content>
+
+  <div class="page-top">
+    <ath-section title="Enregistrés"></ath-section>
+  </div>
+
+  <ng-container *ngIf="(favorites$ | async) as favorites">
+    <div *ngIf="favorites.length === 0" class="empty-state">
+      <ion-icon name="bookmark-outline"></ion-icon>
+      <p>Aucun article enregistré pour l'instant.</p>
+      <p class="empty-hint">Touchez l'icône <ion-icon name="bookmark-outline"></ion-icon> sur un article pour le retrouver ici.</p>
+    </div>
+
+    <div class="saved-list">
+      <article class="saved-card" *ngFor="let article of favorites" (click)="open(article)">
+        <div class="saved-card__thumb" *ngIf="article.imageUrl">
+          <img [src]="article.imageUrl" alt="" loading="lazy">
+        </div>
+        <div class="saved-card__body">
+          <div class="saved-card__kicker">
+            <img class="saved-card__logo" *ngIf="article.mediaLogo" [src]="article.mediaLogo" alt="">
+            <span class="saved-card__source">{{article.mediaTitle}}</span>
+            <span class="saved-card__sep" *ngIf="article.publishedAt">·</span>
+            <span class="saved-card__date" *ngIf="article.publishedAt">{{article.publishedAt | date:'d MMM yyyy'}}</span>
+          </div>
+          <h3 class="saved-card__title" [innerHTML]="article.title"></h3>
+        </div>
+        <button class="saved-card__remove" type="button" aria-label="Retirer" (click)="remove($event, article)">
+          <ion-icon name="trash-outline"></ion-icon>
+        </button>
+      </article>
+    </div>
+  </ng-container>
+
+</ion-content>

--- a/src/app/pages/saved/saved.page.scss
+++ b/src/app/pages/saved/saved.page.scss
@@ -1,0 +1,157 @@
+.page-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--ath-gutter);
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 64px 32px;
+  color: var(--ath-text-dim);
+
+  > ion-icon {
+    font-size: 48px;
+    margin-bottom: 12px;
+    color: var(--ath-text-faint);
+  }
+
+  p {
+    margin: 4px 0;
+    font-family: var(--ath-font-ui);
+    font-size: 14px;
+  }
+
+  .empty-hint {
+    font-size: 12.5px;
+    color: var(--ath-text-faint);
+
+    ion-icon {
+      vertical-align: -2px;
+      font-size: 14px;
+    }
+  }
+}
+
+.saved-list {
+  padding: 0 var(--ath-gutter) 16px;
+}
+
+.saved-card {
+  display: flex;
+  align-items: stretch;
+  gap: 12px;
+  padding: 10px;
+  margin-bottom: 10px;
+  background: var(--ath-surface);
+  border: 1px solid var(--ath-border);
+  border-radius: var(--ath-radius);
+  cursor: pointer;
+  transition: border-color .15s ease, transform .15s ease;
+
+  &:active {
+    transform: scale(.99);
+    border-color: var(--ath-primary);
+  }
+}
+
+.saved-card__thumb {
+  flex-shrink: 0;
+  width: 96px;
+  aspect-ratio: 16 / 9;
+  border-radius: calc(var(--ath-radius) - 4px);
+  overflow: hidden;
+  background: var(--ath-surface-2);
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+}
+
+.saved-card__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.saved-card__kicker {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 5px;
+  min-width: 0;
+}
+
+.saved-card__logo {
+  width: 16px;
+  height: 16px;
+  border-radius: 5px;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: var(--ath-surface-2);
+}
+
+.saved-card__source {
+  font-family: var(--ath-font-ui);
+  font-weight: 600;
+  font-size: 11.5px;
+  color: var(--ath-text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.saved-card__sep {
+  font-size: 11.5px;
+  color: var(--ath-text-faint);
+  flex-shrink: 0;
+}
+
+.saved-card__date {
+  font-family: var(--ath-font-ui);
+  font-size: 11.5px;
+  color: var(--ath-text-dim);
+  flex-shrink: 0;
+}
+
+.saved-card__title {
+  margin: 0;
+  font-family: var(--ath-font-display);
+  font-weight: 700;
+  font-size: 14.5px;
+  line-height: 1.3;
+  color: var(--ath-text);
+
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.saved-card__remove {
+  flex-shrink: 0;
+  align-self: flex-start;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: var(--ath-text-faint);
+  cursor: pointer;
+
+  ion-icon {
+    font-size: 18px;
+  }
+
+  &:active {
+    color: var(--ath-primary);
+  }
+}

--- a/src/app/pages/saved/saved.page.ts
+++ b/src/app/pages/saved/saved.page.ts
@@ -1,0 +1,34 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { Observable } from 'rxjs';
+import { SavedArticle } from '../../models/favorite/saved-article';
+import { FavoritesService } from '../../provider/favorites.service';
+
+/**
+ * Page « Enregistrés » : liste les articles mis en favori (stockage local).
+ * Tap → ouvre l'article ; bouton corbeille → retire le favori.
+ */
+@Component({
+  selector: 'ath-saved',
+  templateUrl: './saved.page.html',
+  styleUrls: ['./saved.page.scss'],
+})
+export class SavedPage {
+  favorites$: Observable<SavedArticle[]>;
+
+  constructor(
+    private readonly favoritesService: FavoritesService,
+    private readonly router: Router
+  ) {
+    this.favorites$ = this.favoritesService.getFavorites();
+  }
+
+  open(article: SavedArticle): void {
+    this.router.navigate(['/', 'media', article.mediaKey, 'details', article.resourceId]);
+  }
+
+  remove(event: Event, article: SavedArticle): void {
+    event.stopPropagation();
+    this.favoritesService.remove(article.key);
+  }
+}

--- a/src/app/pages/tabs/tabs-routing.module.ts
+++ b/src/app/pages/tabs/tabs-routing.module.ts
@@ -32,6 +32,10 @@ const routes: Routes = [
         loadChildren: () => import('../informations/informations.module').then(m => m.InformationsPageModule)
       },
       {
+        path: 'saved',
+        loadChildren: () => import('../saved/saved.module').then(m => m.SavedPageModule)
+      },
+      {
         path: '',
         redirectTo: 'feed',
         pathMatch: 'full'

--- a/src/app/provider/favorites.service.ts
+++ b/src/app/provider/favorites.service.ts
@@ -1,0 +1,92 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { MixedContent } from './content/mixed-content';
+import { SavedArticle, toSavedArticle } from '../models/favorite/saved-article';
+import { StorageService } from './helper/storage.service';
+
+/**
+ * Favoris d'articles, offline-first : persistance locale (SQLite via
+ * StorageService) + cache mémoire exposé en BehaviorSubject pour que les boutons
+ * et la page « Enregistrés » réagissent instantanément. Miroir mobile de la
+ * reading-list de la PWA. Dédup par `SavedArticle.key` (mediaKey:resourceId).
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class FavoritesService {
+  private static MAX_ENTRIES = 300;
+
+  private readonly favorites$ = new BehaviorSubject<SavedArticle[]>([]);
+
+  constructor(private readonly storage: StorageService) {
+    this.load();
+  }
+
+  /** Liste des favoris (triés du plus récent au plus ancien). */
+  public getFavorites(): Observable<SavedArticle[]> {
+    return this.favorites$.asObservable();
+  }
+
+  /** Indique si un favori (par clé) est enregistré, en flux. */
+  public isSaved$(key: string): Observable<boolean> {
+    return this.favorites$.pipe(map((list) => list.some((a) => a.key === key)));
+  }
+
+  /** Version synchrone (cache mémoire) pour l'affichage immédiat des boutons. */
+  public isSaved(key: string): boolean {
+    return this.favorites$.value.some((a) => a.key === key);
+  }
+
+  /**
+   * Bascule l'état favori d'un article du feed. Retourne le nouvel état
+   * (true = enregistré).
+   */
+  public toggle(content: MixedContent): boolean {
+    return this.toggleArticle(toSavedArticle(content));
+  }
+
+  /**
+   * Bascule l'état favori à partir d'un SavedArticle déjà construit (page
+   * détail). Retourne le nouvel état (true = enregistré).
+   */
+  public toggleArticle(article: SavedArticle): boolean {
+    if (this.isSaved(article.key)) {
+      this.remove(article.key);
+      return false;
+    }
+    this.add(article);
+    return true;
+  }
+
+  /** Ajoute (ou rafraîchit) un favori. */
+  public add(article: SavedArticle): void {
+    const list = this.favorites$.value.filter((a) => a.key !== article.key);
+    list.unshift(article);
+    this.persist(list.slice(0, FavoritesService.MAX_ENTRIES));
+  }
+
+  /** Retire un favori par clé. */
+  public remove(key: string): void {
+    this.persist(this.favorites$.value.filter((a) => a.key !== key));
+  }
+
+  private load(): void {
+    this.storage.get<SavedArticle[]>(StorageService.SAVED_ARTICLES).subscribe((stored) => {
+      const list = Array.isArray(stored) ? stored : [];
+      this.favorites$.next(this.sort(list));
+    });
+  }
+
+  private persist(list: SavedArticle[]): void {
+    const sorted = this.sort(list);
+    this.favorites$.next(sorted);
+    this.storage.set(StorageService.SAVED_ARTICLES, sorted);
+  }
+
+  private sort(list: SavedArticle[]): SavedArticle[] {
+    return [...list].sort(
+      (a, b) => new Date(b.savedAt).getTime() - new Date(a.savedAt).getTime()
+    );
+  }
+}

--- a/src/app/provider/helper/anon-key.service.ts
+++ b/src/app/provider/helper/anon-key.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { switchMap, tap } from 'rxjs/operators';
+import { StorageService } from './storage.service';
+
+/**
+ * Clé anonyme stable par appareil, pour la dédup serveur des votes roadmap
+ * quand l'utilisateur n'est pas connecté (cf. athena_api IdeaVote.anonKey et
+ * l'entête `X-Anon-Key`). Générée une fois, persistée via StorageService
+ * (SQLite), puis réutilisée. Équivalent mobile de athena-pwa/src/lib/anon-key.ts.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class AnonKeyService {
+  private cachedKey: string | null = null;
+
+  constructor(private readonly storage: StorageService) {}
+
+  /**
+   * Retourne la clé anonyme de l'appareil, en la générant et la persistant
+   * au premier appel. Les appels suivants utilisent la valeur en cache.
+   */
+  public getAnonKey(): Observable<string> {
+    if (this.cachedKey) {
+      return of(this.cachedKey);
+    }
+
+    return this.storage.get<string>(StorageService.ANON_KEY).pipe(
+      switchMap((stored) => {
+        if (stored) {
+          return of(stored);
+        }
+        const generated = this.generateKey();
+        this.storage.set(StorageService.ANON_KEY, generated);
+        return of(generated);
+      }),
+      tap((key) => (this.cachedKey = key)),
+    );
+  }
+
+  private generateKey(): string {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+      return crypto.randomUUID();
+    }
+    return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  }
+}

--- a/src/app/provider/helper/http.service.ts
+++ b/src/app/provider/helper/http.service.ts
@@ -39,14 +39,24 @@ export class HttpService {
     return get$;
   }
 
-  post<T>(url: string, body?: any, ignoreCors?: boolean): Observable<T> {
+  post<T>(url: string, body?: any, ignoreCors?: boolean, customHeaders?: Record<string, string>): Observable<T> {
     let post$;
     if (this.develop || !ignoreCors) {
-      post$ = this.developPost(url, body);
+      post$ = this.developPost(url, body, customHeaders);
     } else {
-      post$ = this.nativePost(url, body);
+      post$ = this.nativePost(url, body, customHeaders);
     }
     return post$;
+  }
+
+  delete<T>(url: string, ignoreCors?: boolean, customHeaders?: Record<string, string>): Observable<T> {
+    let delete$;
+    if (this.develop || !ignoreCors) {
+      delete$ = this.developDelete(url, customHeaders);
+    } else {
+      delete$ = this.nativeDelete(url, customHeaders);
+    }
+    return delete$;
   }
 
   /**
@@ -84,17 +94,10 @@ export class HttpService {
    * La methode qui post en natif
    * @param url L'url a post
    * @param body le body a poster
+   * @param customHeaders entêtes additionnels (ex: X-Anon-Key)
    */
-  private nativePost(url: string, body?: any) {
-    const headers: any = {
-      "Content-Type": "application/json",
-    };
-
-    // Ajouter le token d'authentification si disponible
-    const token = this.authService.getCachedToken();
-    if (token) {
-      headers["Authorization"] = `Bearer ${token}`;
-    }
+  private nativePost(url: string, body?: any, customHeaders?: Record<string, string>) {
+    const headers = this.buildNativeHeaders(customHeaders);
 
     return from(this.nativeHttp.post(url, body, headers)).pipe(
       runInZone(this.zone),
@@ -105,8 +108,53 @@ export class HttpService {
    * La methode qui call en broswer
    * @param url l'url a get
    * @param body le body a poster
+   * @param customHeaders entêtes additionnels (ex: X-Anon-Key)
    */
-  private developPost(url: string, body?: any) {
-    return this.developHttp.post(url, body);
+  private developPost(url: string, body?: any, customHeaders?: Record<string, string>) {
+    return this.developHttp.post(url, body, customHeaders ? { headers: customHeaders } : {});
+  }
+
+  /**
+   * La methode qui delete en natif
+   * @param url L'url a delete
+   * @param customHeaders entêtes additionnels (ex: X-Anon-Key)
+   */
+  private nativeDelete(url: string, customHeaders?: Record<string, string>) {
+    const headers = this.buildNativeHeaders(customHeaders);
+
+    return from(this.nativeHttp.delete(url, {}, headers)).pipe(
+      runInZone(this.zone),
+      map((data: HTTPResponse) => JSON.parse(data.data || 'null'))
+    );
+  }
+  /**
+   * La methode qui delete en browser
+   * @param url l'url a delete
+   * @param customHeaders entêtes additionnels (ex: X-Anon-Key)
+   */
+  private developDelete(url: string, customHeaders?: Record<string, string>) {
+    return this.developHttp.delete(url, customHeaders ? { headers: customHeaders } : {});
+  }
+
+  /**
+   * Construit les entêtes pour les appels natifs : JSON + Bearer Firebase si
+   * disponible + entêtes additionnels éventuels.
+   */
+  private buildNativeHeaders(customHeaders?: Record<string, string>): any {
+    const headers: any = {
+      "Content-Type": "application/json",
+      "Accept": "application/json",
+    };
+
+    const token = this.authService.getCachedToken();
+    if (token) {
+      headers["Authorization"] = `Bearer ${token}`;
+    }
+
+    if (customHeaders) {
+      Object.assign(headers, customHeaders);
+    }
+
+    return headers;
   }
 }

--- a/src/app/provider/helper/storage.service.ts
+++ b/src/app/provider/helper/storage.service.ts
@@ -12,6 +12,10 @@ export class StorageService {
   public static COUNT_KEY = 'COUNT_KEY';
   public static INSTALLATION_DATE = 'INSTALLATION_DATE';
   public static CLAPPED_ISSUE = 'CLAPPED_ISSUE';
+  public static DOWNVOTED_ISSUE = 'DOWNVOTED_ISSUE';
+  public static ANON_KEY = 'ANON_KEY';
+  public static SAVED_ARTICLES = 'SAVED_ARTICLES';
+  public static NOTIFICATIONS_MASTER_ENABLED = 'NOTIFICATIONS_MASTER_ENABLED';
   private static FIRST_LAUNCH = 'FIRST_LAUNCH';
 
 
@@ -65,6 +69,22 @@ export class StorageService {
       }
       array.push(value);
       this.set(key, array);
+    }));
+  }
+
+
+  /**
+   * Cette methode retire un element d'un tableau contenu dans le storage
+   * @param key la clé qui définie le tableau dans le localstorage
+   * @param value la valeur a retirer du tableau
+   */
+  public removeFromArray(key: string, value: any): Observable<any> {
+    return this.get<any[]>(key).pipe(tap((array: any[]) => {
+      if (array == null || !Array.isArray(array)) {
+        return;
+      }
+      const filtered = array.filter((item) => item !== value);
+      this.set(key, filtered);
     }));
   }
 

--- a/src/app/provider/idea.service.ts
+++ b/src/app/provider/idea.service.ts
@@ -2,9 +2,10 @@ import { Injectable } from "@angular/core";
 import { forkJoin, Observable } from "rxjs";
 import { environment } from "../../environments/environment.prod";
 import { Issue } from "../models/idea/idea";
+import { AnonKeyService } from "./helper/anon-key.service";
 import { HttpService } from "./helper/http.service";
 import { StorageService } from './helper/storage.service';
-import { map } from 'rxjs/operators';
+import { map, switchMap } from 'rxjs/operators';
 
 @Injectable({
   providedIn: "root",
@@ -13,6 +14,7 @@ export class IdeaService {
   public static BASE_ATHENA_URL = environment.apiUrl;
   private static ISSUE = "issues";
   private static CLAP = "/clap";
+  private static DOWNVOTE = "/downvote";
 
   /**
    * Source des idées : API Athena (BDD) — migration depuis les GitHub issues.
@@ -22,18 +24,26 @@ export class IdeaService {
   private static FULL_ATHENA_ISSUE_URL =
     IdeaService.BASE_ATHENA_URL + IdeaService.ISSUE;
 
-  constructor(private readonly http: HttpService, private readonly storage: StorageService) { }
+  constructor(
+    private readonly http: HttpService,
+    private readonly storage: StorageService,
+    private readonly anonKey: AnonKeyService,
+  ) { }
 
   getIssuesByLabel(label: string): Observable<Issue[]> {
 
     return forkJoin([
       this.http.get<Issue[]>(IdeaService.FULL_ATHENA_ISSUE_URL + `?labels=${label}`),
-      this.storage.get<number[]>(StorageService.CLAPPED_ISSUE)
+      this.storage.get<number[]>(StorageService.CLAPPED_ISSUE),
+      this.storage.get<number[]>(StorageService.DOWNVOTED_ISSUE)
     ]).pipe(
-      map(([issues, alreadyClappedIssuesId]) => {
+      map(([issues, alreadyClappedIssuesId, alreadyDownvotedIssuesId]) => {
         return issues.map(i => {
           if (alreadyClappedIssuesId && alreadyClappedIssuesId.includes(i.id)) {
             i.hasBeenClapped = true;
+          }
+          if (alreadyDownvotedIssuesId && alreadyDownvotedIssuesId.includes(i.id)) {
+            i.hasBeenDownvoted = true;
           }
           return i;
         });
@@ -46,20 +56,71 @@ export class IdeaService {
   }
 
   postIssue(issue: Issue): Observable<Issue> {
-    return this.http.post(
-      IdeaService.BASE_ATHENA_URL + IdeaService.ISSUE,
-      issue
+    return this.anonKey.getAnonKey().pipe(
+      switchMap((key) =>
+        this.http.post<Issue>(
+          IdeaService.BASE_ATHENA_URL + IdeaService.ISSUE,
+          issue,
+          false,
+          { "X-Anon-Key": key }
+        )
+      )
     );
   }
 
+  /**
+   * Vote « pour » (clap). Reste anonyme : on envoie la clé anonyme stable de
+   * l'appareil en entête `X-Anon-Key` pour la dédup serveur (cf. #252/#273/#101).
+   */
   postClapComment(issue: Issue): Observable<Issue> {
-    const url =
+    const url = this.clapUrl(issue);
+    return this.anonKey.getAnonKey().pipe(
+      switchMap((key) => this.http.post<Issue>(url, {}, false, { "X-Anon-Key": key }))
+    );
+  }
+
+  /**
+   * Retire le vote « pour » (toggle). Même clé anonyme que le clap.
+   */
+  deleteClap(issue: Issue): Observable<Issue> {
+    const url = this.clapUrl(issue);
+    return this.anonKey.getAnonKey().pipe(
+      switchMap((key) => this.http.delete<Issue>(url, false, { "X-Anon-Key": key }))
+    );
+  }
+
+  /**
+   * Vote « contre » (downvote) — AUTH FIREBASE REQUISE. Le Bearer est ajouté
+   * automatiquement par l'intercepteur (web) / HttpService (natif).
+   */
+  postDownvote(issue: Issue): Observable<Issue> {
+    return this.http.post<Issue>(this.downvoteUrl(issue), {});
+  }
+
+  /**
+   * Retire le vote « contre » (toggle). Auth Firebase requise.
+   */
+  deleteDownvote(issue: Issue): Observable<Issue> {
+    return this.http.delete<Issue>(this.downvoteUrl(issue));
+  }
+
+  private clapUrl(issue: Issue): string {
+    return (
       IdeaService.BASE_ATHENA_URL +
       IdeaService.ISSUE +
       "/" +
       issue.number +
-      IdeaService.CLAP;
+      IdeaService.CLAP
+    );
+  }
 
-    return this.http.post(url, {});
+  private downvoteUrl(issue: Issue): string {
+    return (
+      IdeaService.BASE_ATHENA_URL +
+      IdeaService.ISSUE +
+      "/" +
+      issue.number +
+      IdeaService.DOWNVOTE
+    );
   }
 }

--- a/src/app/provider/notification.service.ts
+++ b/src/app/provider/notification.service.ts
@@ -142,6 +142,41 @@ export class NotificationService {
     return makeDiff$;
   }
 
+  /**
+   * État du « master switch » des notifications. true par défaut (opt-out).
+   */
+  public isNotificationsMasterEnabled(): Observable<boolean> {
+    return this.ss
+      .get<boolean>(StorageService.NOTIFICATIONS_MASTER_ENABLED)
+      .pipe(map((val) => (val == null ? true : val)));
+  }
+
+  /**
+   * Active ou coupe d'un coup toutes les notifications : (dés)abonne tous les
+   * métamédias connus et persiste l'état global. Évite à l'utilisateur de le
+   * faire média par média (#90).
+   */
+  public setAllNotifications(enabled: boolean): Observable<any> {
+    this.ss.set(StorageService.NOTIFICATIONS_MASTER_ENABLED, enabled);
+    const keys = this.collectAllMetaMediaKeys();
+    if (keys.length === 0) {
+      return of([]);
+    }
+    return enabled
+      ? this.subscribeAllMetaMedia(keys)
+      : this.unsubscribeAllMetaMedia(keys);
+  }
+
+  private collectAllMetaMediaKeys(): string[] {
+    const keys: string[] = [];
+    for (const list of this.metaMediaService.listMetaMedia) {
+      for (const metaMedia of list.metaMedias) {
+        keys.push(metaMedia.key);
+      }
+    }
+    return keys;
+  }
+
   public isCategoryActivated(key: string, id: number) {
     const unsubCategories = this.notificationTopicsCategories[key];
     if (!unsubCategories || unsubCategories.length === 0) {
@@ -333,11 +368,11 @@ export class NotificationService {
     return concat(...subAll$);
   }
 
-  // Si jamais un jour on veut faire une options pour couper toutes les notifications
-  // private unsubscribeAllMetaMedia(topics: string[]): Observable<any[]> {
-  //   const unsubAll$ = topics.map((topic) => this.unsubscribeMetaMedia(topic));
-  //   return concat(...unsubAll$);
-  // }
+  private unsubscribeAllMetaMedia(topics: string[]): Observable<any[]> {
+    this.checkNullOrEmpty(topics);
+    const unsubAll$ = topics.map((topic) => this.unsubscribeMetaMedia(topic));
+    return concat(...unsubAll$);
+  }
 
   private subscribeMetaMedia(topic: string): Observable<any> {
     return this.subscribeTopic(topic).pipe(

--- a/src/app/provider/secondary-menu.service.ts
+++ b/src/app/provider/secondary-menu.service.ts
@@ -19,6 +19,13 @@ export class SecondaryMenuService {
       cssClass: 'secondary-menu-sheet',
       buttons: [
         {
+          text: 'Enregistrés',
+          icon: 'bookmark-outline',
+          handler: () => {
+            this.router.navigateByUrl('/tabs/saved');
+          },
+        },
+        {
           text: 'Infos & à propos',
           icon: 'information-circle-outline',
           handler: () => {


### PR DESCRIPTION
## Contexte

Uniformisation des fonctionnalités entre la PWA (déjà livrée en prod) et l'app mobile Ionic, sur la base de l'audit des idées les mieux votées (`EVALUATION-IDEES-TOP30.md`). Ces fonctions existaient déjà côté PWA ; ce lot les porte sur le natif pour rétablir la parité.

## Idées couvertes

- **#252 / #273 / #101 - Dédup des votes (2139 votes cumulés)** : l'app mobile envoie désormais un header `X-Anon-Key` (clé device stable persistée, miroir de `athena-pwa/src/lib/anon-key.ts`) sur clap/unclap/postIssue. La dédup serveur existait déjà mais le mobile ne l'utilisait pas → 3 bugs réglés d'un coup.
- **#161 - Favoris d'articles (111 votes)** : `FavoritesService` offline-first (persistance locale + cache mémoire réactif), bouton sur les cartes et la page détail, nouvelle page « Enregistrés ». Miroir de la reading-list PWA.
- **#90 - Réglages notifications (90 votes)** : master switch « couper toutes les notifs » (opt-out, réactive le code natif qui était commenté) dans la page Informations.
- **#131 - Vote contre (212 votes)** : downvote auth-gated (Bearer Firebase), 2ᵉ pouce dans la liste d'idées, toggle persisté localement.

## Détails techniques

- `HttpService` : support des `customHeaders` sur POST + nouvelle méthode `delete` (natif + browser), Bearer Firebase préservé via `buildNativeHeaders`.
- `StorageService` : nouvelles clés (`ANON_KEY`, `SAVED_ARTICLES`, `DOWNVOTED_ISSUE`, `NOTIFICATIONS_MASTER_ENABLED`) + `removeFromArray`.
- Aucune migration backend (les endpoints downvote/clap existent déjà sur `master` de l'API).

## Test plan (device)

- [ ] Voter/dévoter une idée plusieurs fois → un seul vote compté côté serveur (dédup via X-Anon-Key)
- [ ] Downvote sur une idée en étant connecté (Firebase) → refusé si déconnecté
- [ ] Enregistrer un article (carte + détail), le retrouver dans « Enregistrés », le retirer
- [ ] Couper le master switch notifs → plus de notif ; réactiver → notifs reçues
- [ ] Persistance après redémarrage app (favoris, votes, état master switch)

Build prod OK (AOT).